### PR TITLE
Regex

### DIFF
--- a/src/renderer/components/Index/MenuWindow.vue
+++ b/src/renderer/components/Index/MenuWindow.vue
@@ -82,7 +82,7 @@ export default {
     },
     bgURL: {
       set (value) {
-        if (value.match(/\.(jpeg|jpg|png)$/)) {
+        if (value.match(/\.(?:jpeg|jpg|png)$/i)) {
           this.$store.commit('setBackgroundURL', value)
         }
       },


### PR DESCRIPTION
Always use non-capturing brackets if you don't need the value
Plus case insensitivity for files like sas.JPEG